### PR TITLE
Skipping posting of issues if checked source code is outdated

### DIFF
--- a/input/docs/overview/features.md
+++ b/input/docs/overview/features.md
@@ -23,6 +23,7 @@ The core addins provide the following functionality:
   * `ReportIssuesToPullRequest` aliases for writing issues as comments to pull requests.
   * Support for reporting issues from multiple issue providers.
   * Filtering issues to only those related to changes in a pull request.
+  * Skipping posting of issues if checked source code is outdated
   * Automatic resolving of issues fixed in subsequent commits.
   * Comparing issues by content to not rely on line numbers.
   * Limit number of maximum issues to post.


### PR DESCRIPTION
Add skipping posting of issues if checked source code is outdated feature

Implemented in https://github.com/cake-contrib/Cake.Issues.PullRequests/pull/12