### PR TITLE
Document that Json.NET is available in Razor templates

### DIFF
--- a/input/docs/report-formats/generic/examples.md
+++ b/input/docs/report-formats/generic/examples.md
@@ -144,6 +144,7 @@ In custom templates functionality from the following assemblies are available:
 * System.dll
 * System.Core.dll
 * netstandard.dll
+* Newtonsoft.Json.dll
 * Cake.Core.dll
 * Cake.Issues.dll
 


### PR DESCRIPTION
Document that Json.NET is available in Razor templates as implemented with https://github.com/cake-contrib/Cake.Issues.Reporting.Generic/pull/36/