### PR TITLE
Remove alias for voting which is now part of Cake.Tfs

### DIFF
--- a/input/docs/pull-request-systems/tfs/features.md
+++ b/input/docs/pull-request-systems/tfs/features.md
@@ -12,7 +12,6 @@ The [Cake.Issues.PullRequests.Tfs addin] provides the following features.
 * Comments written by the addin will be rendered with a specific icon corresponding to the state of the issue.
 * Adds rule number and, if provided by the issue provider, link to the rule description to the comment.
 * Support for issues messages formatted in Markdown format.
-* Alias for approving or voting pull requests.
 
 # Supported capabilities
 


### PR DESCRIPTION
Remove alias for voting which is now part of Cake.Tfs