### PR TITLE
Add support for IIssue.RuleUrl in Cake.Issues.GitRepository

### DIFF
--- a/input/docs/issue-providers/gitrepository/features.md
+++ b/input/docs/issue-providers/gitrepository/features.md
@@ -31,6 +31,6 @@ The [Cake.Issues.GitRepository addin] provides the following features.
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Priority`                 |                                |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.PriorityName`             |                                |
 | <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.Rule`                     |                                |
-| <span class="glyphicon glyphicon-remove" style="color:red"></span> | `IIssue.RuleUrl`                  |                                |
+| <span class="glyphicon glyphicon-ok" style="color:green"></span>   | `IIssue.RuleUrl`                  |                                |
 
 [Cake.Issues.GitRepository addin]: https://www.nuget.org/packages/Cake.Issues.GitRepository


### PR DESCRIPTION
Support for IIssue.RuleUrl was added to Cake.Issues.GitRepository with https://github.com/cake-contrib/Cake.Issues.GitRepository/commit/0f93cd5eda070a89efe24095c1f9c60feba13c1b