### PR TITLE
Add Cake.Issues.DupFinder

### DIFF
--- a/addins/Cake.Issues.DupFinder.yml
+++ b/addins/Cake.Issues.DupFinder.yml
@@ -1,0 +1,14 @@
+Name: JetBrains dupFinder Support
+NuGet: Cake.Issues.DupFinder
+Prerelease: true
+RepositoryOwner: cake-contrib
+RepositoryName: Cake.Issues.DupFinder
+RepositoryDocumentationPath: ./docs
+DocumentationLink: /docs/issue-providers/dupfinder
+ReleaseNotesFilePath: "input/docs/issue-providers/dupfinder/release-notes.md"
+Assemblies:
+- "/**/Cake.Issues.DupFinder.dll"
+Author: janniksam
+Description: "Support for reading issues reported by JetBrains dupFinder"
+Categories:
+- Issue Provider


### PR DESCRIPTION
Add Cake.Issues.DupFinder to https://cakeissues.net once a first version is published to nuget.org and https://github.com/cake-contrib/Cake.Issues.DupFinder/pull/7 is merged