### PR TITLE
Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo and
 # will be requested for review when someone opens a pull request.
-*       @pascalberger @christianbumann @x-jokay @silanosa @georgesgoetz
+*       @cake-contrib/team-cake-issues


### PR DESCRIPTION
Update code owners. On other Cake.Issues repositories we already have code owners set to `Team BBT` and other contributors. I would like to simplify this further by just having a single `Team Cake.Issues` containing all maintainers.