### PR TITLE
Add introduction page

### DIFF
--- a/input/docs/overview/features.md
+++ b/input/docs/overview/features.md
@@ -1,5 +1,5 @@
 ---
-Order: 10
+Order: 20
 Description: Overview about core features.
 ---
 The Cake Issues addins for Cake allows you to read issues from any analyzer or linter,
@@ -28,7 +28,7 @@ Addin for creating and reading issues providing the following functionality:
 ## Cake.Issues.Reporting
 
 Addin for creating reports providing the following functionality:
-  
+
 * [CreateIssueReport] aliases for creating reports about issues.
 * Support for creating reports with issues from multiple issue providers.
 

--- a/input/docs/overview/introduction.md
+++ b/input/docs/overview/introduction.md
@@ -1,0 +1,30 @@
+---
+Order: 10
+Description: Introduction
+---
+Do you want to break your build on JetBrains InspectCode issues?
+Do you want to create nice reports for StyleCop issues in your code?
+Do you want to have ESLint issues reported as comments to pull requests?
+The Cake.Issues addins allows you to do this and much more.
+Read issues from different analyzer or linters, create reports or add them as comments to pull requests.
+
+While some linting tools provide nice reporting capabilities, others don't.
+Some build systems provide tasks to report issues into pull requests.
+But if you're using another build system your out of luck.
+Maybe you found a new nice linting tool which does exactly what you need,
+but probably it won't integrate well with your existing other linting tools.
+
+The Cake.Issues addins tries to solve this, by providing a common and extensible infrastructure
+for issue management in Cake build scripts.
+
+Unlike other Cake addins, the Cake Issues addin consists of over 15 different addins,
+working together and providing over 75 aliases which can be used in Cake build scripts to work with issues.
+The addins are built in a modular architecture and are providing different extension points which allows to easily
+enhance them for supporting additional analyzers, linters, report formats and code review systems.
+
+<a class="btn btn-primary btn-lg" href="https://gitpitch.com/pascalberger/Cake.Issues-Presentation" target="_blank" role="button">
+    <span class="glyphicon glyphicon-facetime-video"></span> Presentation
+</a>
+<a class="btn btn-primary btn-lg" href="/docs/usage" role="button">
+    <span class="glyphicon glyphicon-book"></span> Tutorials
+</a>

--- a/input/docs/overview/requirements.md
+++ b/input/docs/overview/requirements.md
@@ -1,5 +1,5 @@
 ---
-Order: 20
+Order: 30
 Description: Requirements for using Cake.Issues.
 ---
 The requirements for core addins are listed in the release notes for any specific version:

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -31,7 +31,7 @@ NoGutter: true
             <span class="glyphicon glyphicon-globe logo-small"></span>
             <h3 class="no-anchor">Rich ecosystem</h3>
             <p>
-                Unlike other Cake addins, Cake Issues consists of over 10 different <a href="addins">addins</a>,
+                Unlike other Cake addins, Cake Issues consists of over 15 different <a href="addins">addins</a>,
                 working together and providing you with over 75 <a href="dsl">aliases</a> which you can use in your Cake
                 build scripts to work with issues.
             </p>


### PR DESCRIPTION
Adds an introduction page to give an overview about Cake Issues and provide links to presentation and tutorials.

![image](https://user-images.githubusercontent.com/2190718/96310796-5d896400-1008-11eb-8ddf-4ac6ed2cdf3e.png)
