### PR TITLE
Fix old release notes for merged packages

### DIFF
--- a/addins/Cake.Issues.PullRequests.yml
+++ b/addins/Cake.Issues.PullRequests.yml
@@ -4,7 +4,6 @@ Prerelease: false
 RepositoryOwner: cake-contrib
 RepositoryName: Cake.Issues
 DocumentationLink: /docs/usage/reporting-issues-to-pull-requests/
-ReleaseNotesFilePath: "input/docs/overview/release-notes/Cake.Issues.PullRequests.md"
 Assemblies:
 - "/**/Cake.Issues.PullRequests.dll"
 Author: BBT Software AG and contributors

--- a/addins/Cake.Issues.Reporting.yml
+++ b/addins/Cake.Issues.Reporting.yml
@@ -4,7 +4,6 @@ Prerelease: false
 RepositoryOwner: cake-contrib
 RepositoryName: Cake.Issues
 DocumentationLink: /docs/usage/creating-reports/
-ReleaseNotesFilePath: "input/docs/overview/release-notes/Cake.Issues.Reporting.md"
 Assemblies:
 - "/**/Cake.Issues.Reporting.dll"
 Author: BBT Software AG and contributors

--- a/input/docs/overview/release-notes/Cake.Issues.PullRequests.md
+++ b/input/docs/overview/release-notes/Cake.Issues.PullRequests.md
@@ -1,0 +1,930 @@
+---
+Title: Cake.Issues.PullRequests Release Notes
+Description: Release notes for Cake.Issues.PullRequests
+---
+<p>
+<div class="alert alert-warning">
+<p>
+Starting with Cake.Issues 1.0, release notes for Cake.Issues.PullRequests will be listed with <a href='/docs/overview/release-notes/Cake.Issues'>Cake.Issues Release Notes</a>.
+The release notes on this page are only for versions of Cake.Issues.PullRequests prior to 1.0.
+</p>
+</div>
+</p>
+
+## 0.9.1 (October 08, 2020)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/15?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.x
+- Targeting .NET Standard 2.0
+
+__Bug__
+
+- [__#173__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/173) Setting a ProviderLimit to zero will ignore the limit instead of posting 0 items
+
+
+## 0.9.0 (August 22, 2020)
+
+
+As part of this release we had [4 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/13?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.x
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#154__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/154) Update to Cake.Issues 0.9.0
+
+__Features__
+
+- [__#143__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/143) Use identifier different from displayed message to compare existing issues
+- [__#142__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/142) Add setting to limit number of issues posted to a pull request across multiple runs for issue providers
+- [__#141__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/141) Add possibility to limit posted issues for a specific provider
+
+
+## 0.9.0-beta.3 (August 01, 2020)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.0-beta0004
+- Targeting .NET Standard 2.0
+
+__Breaking Changes__
+
+- Update to Cake.Issues 0.9.0-beta0004
+## 0.9.0-beta.2 (July 18, 2020)
+
+
+As part of this release we had 3 issues closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.0-beta0002
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#143__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/143) Use identifier different from displayed message to compare existing issues
+- [__#142__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/142) Add setting to limit number of issues posted to a pull request across multiple runs for issue providers
+- [__#141__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/141) Add possibility to limit posted issues for a specific provider
+
+
+## 0.9.0-beta.1 (July 14, 2020)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.0-beta0002
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#154__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/154) Update to Cake.Issues 0.9.0
+
+
+## 0.8.1 (May 03, 2020)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/12?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.x
+- Targeting .NET Standard 2.0
+
+__Bug__
+
+- [__#136__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/136) Don't log issues if they are not posted due to outdated commit
+
+__Improvement__
+
+- [__#134__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/134) Add setting to limit number of issues posted to a pull request across multiple runs
+
+
+## 0.8.1-beta.2 (April 29, 2020)
+
+
+As part of this release we had 1 issue closed compared to 0.8.1-beta.1.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.x
+- Targeting .NET Standard 2.0
+
+__Bug__
+
+- [__#145__](https://github.com/cake-contrib/Cake.Issues.PullRequests/pull/145) Consider unresolved issues for MaxIssuesToPostAcrossRuns (Thanks @janniksam)
+## 0.8.1-beta.1 (April 27, 2020)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/12?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.x
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- [__#134__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/134) Add setting to limit number of issues posted to a pull request across multiple runs
+
+__Bug__
+
+- [__#136__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/136) Don't log issues if they are not posted due to outdated commit
+## 0.8.0 (October 17, 2019)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/11?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.x
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#113__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/113) Update to Cake.Issues 0.8.0
+
+__Improvements__
+
+- [__#118__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/118) Embed NuGet package icon
+- [__#116__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/116) Improve performance logging for issue filtering
+
+
+## 0.8.0-beta.1 (October 11, 2019)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/11?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.0-beta.1
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#113__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/113) Update to Cake.Issues 0.8.0
+
+
+## 0.7.0 (May 30, 2019)
+
+
+As part of this release we had [32 commits](https://github.com/cake-contrib/Cake.Issues.PullRequests/compare/0.6.2...0.7.0) which resulted in [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/milestone/10?closed=1) being closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.7.x
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#78__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/78) Update to Cake.Issues 0.7.0
+- [__#77__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/77) Build against Cake 0.33.0
+
+
+## 0.7.0-beta.1 (April 19, 2019)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.7.x
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#78__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/78) Update to Cake.Issues 0.7.0
+- [__#77__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/77) Build against Cake 0.33.0
+
+
+## 0.6.2 (December 15, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=9&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+
+__Bug__
+
+- [__#50__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/50) No exception should be thrown if an empty list of issues is passed
+
+
+## 0.6.1 (September 04, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=8&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+
+__Improvement__
+
+- [__#28__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/28) Provide alias which a list of issues can be passed
+
+
+## 0.6.1-beta.1 (September 04, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+
+__Improvement__
+
+- [__#28__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/28) Provide alias which a list of issues can be passed
+
+
+## 0.6.0 (August 24, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=7&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+
+__Breaking changes__
+
+- [__#45__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/45) Update to Cake.Issues 0.6.0
+- [__#43__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/43) Split pull request interface into different capabilities
+
+
+## 0.6.0-beta.2 (August 20, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.0-beta.2
+
+__Breaking changes__
+
+- Update to Cake.Issues 0.6.0 Beta 2
+- Fix error with namespace import
+
+
+## 0.6.0-beta.1 (August 18, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=7&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.0-beta.1
+
+__Breaking changes__
+
+- [__#45__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/45) Update to Cake.Issues 0.6.0
+- [__#43__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/43) Split pull request interface into different capabilities
+
+
+## 0.5.0 (August 17, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=6&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.5.x
+
+__Breaking change__
+
+- [__#41__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/41) Update to Cake.Issues 0.5.0
+
+__Improvement__
+
+- [__#44__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/44) Add repository metadata to nuspec
+
+
+## 0.5.0-beta.1 (August 07, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.5.0-beta.2
+
+__Breaking change__
+
+- [__#41__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/41) Update to Cake.Issues 0.5.0
+
+
+## 0.4.0 (July 28, 2018)
+
+
+As part of this release we had [5 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=5&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.x
+
+__Breaking changes__
+
+- [__#39__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/39) Update to Cake.Issues 0.4.0
+- [__#30__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/30) Support different resolutions for comment thread resolving
+
+__Bugs__
+
+- [__#36__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/36) Only resolve comments with the same comment source
+- [__#29__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/29) Filtering on existing comments sometimes fails
+
+
+## 0.4.0-beta.2 (July 25, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.0-beta.2
+
+__Breaking changes__
+
+- Update Cake.Issues to 0.4.0-beta.2
+## 0.4.0-beta.1 (July 24, 2018)
+
+
+As part of this release we had 5 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.0-beta.1
+
+__Breaking changes__
+
+- [__#39__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/39) Update to Cake.Issues 0.4.0
+- [__#30__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/30) Support different resolutions for comment thread resolving
+
+__Bugs__
+
+- [__#36__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/36) Only resolve comments with the same comment source
+- [__#29__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/29) Filtering on existing comments sometimes fails
+
+
+## 0.3.1 (June 21, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=4&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.3.x
+
+__Feature__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/25) Add support to pass additional filter criterias
+
+
+## 0.3.0 (June 04, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=3&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.3.x
+
+__Breaking changes__
+
+- [__#22__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/22) Build against Cake 0.28.0
+- [__#20__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/20) Update to Cake.Issues 0.3.0
+
+
+## 0.3.0-beta.2 (June 02, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=3&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.3.0-beta.2
+
+__Breaking changes__
+
+- [__#22__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/22) Build against Cake 0.28.0
+- Update to Cake.Issues 0.3.0-beta.2
+## 0.3.0-beta.1 (May 31, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.3.0-beta.1
+
+__Breaking change__
+
+- [__#20__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/20) Update to Cake.Issues 0.3.0
+
+
+## 0.2.0 (May 22, 2018)
+
+
+As part of this release we had [26 commits](https://github.com/cake-contrib/Cake.Issues.PullRequests/compare/0.1.0...0.2.0) which resulted in [6 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=2&state=closed) being closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.x
+
+__Breaking changes__
+
+- [__#18__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/18) Build against Cake 0.26.0
+- [__#16__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/16) Allow to limit maximum issues per issue provider
+- [__#14__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/14) Update to Cake.Issues 0.2.0
+
+__Improvements__
+
+- [__#9__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/9) Migrate to .NET Core
+- [__#2__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/2) Check if pull request is still on the same commit before posting issues
+
+
+## 0.2.0-beta.2 (March 10, 2018)
+
+
+As part of this release we had the following issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.0-beta.4
+
+__Bug__
+
+- Mark as CLS compliant
+
+## 0.2.0-beta.1 (March 08, 2018)
+
+
+As part of this release we had 6 issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.0-beta.3
+
+__Breaking changes__
+
+- [__#18__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/18) Build against Cake 0.26.0
+- [__#16__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/16) Allow to limit maximum issues per issue provider
+- [__#14__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/14) Update to Cake.Issues 0.2.0
+
+__Improvements__
+
+- [__#9__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/9) Migrate to .NET Core
+- [__#2__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/2) Check if pull request is still on the same commit before posting issues
+
+
+## 0.1.0 (September 16, 2017)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues?milestone=1&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Cake.Issues 0.1.x
+
+__Breaking change__
+
+- [__#8__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/8) Update to Cake 0.22
+
+__Feature__
+
+- [__#1__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/1) First version based on Cake.Prca
+
+
+## 0.1.0-beta.3 (September 13, 2017)
+
+
+As part of this release we had 2 issue closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Cake.Issues 0.1.0-beta.4
+
+__Breaking Changes__
+
+- Target .NET Framework 4.6
+- Build against Cake 0.22.0
+- Build against Cake.Issues 0.1.0-beta0004
+## 0.1.0-beta.2 (September 03, 2017)
+
+
+As part of this release we had 2 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.3
+
+__Breaking Changes__
+
+- Update Cake.Issues to 0.1.0-beta0003
+- Move everything into single namespace
+## 0.1.0-beta.1 (September 02, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.2
+
+__Feature__
+
+- [__#1__](https://github.com/cake-contrib/Cake.Issues.PullRequests/issues/1) First version based on Cake.Prca
+e provider infrastructure
+
+
+## 0.4.1 (August 03, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues/issues?milestone=6&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Feature__
+
+- [__#39__](https://github.com/cake-contrib/Cake.Issues/issues/39) Provide infrastructure for issue provider with different formats
+
+
+## 0.4.0 (July 28, 2018)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=5&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#35__](https://github.com/cake-contrib/Cake.Issues/issues/35) Replace `IIssue.Project` with `IIssue.ProjectFileRelativePath` and `IIssue.ProjectName`
+
+__Improvement__
+
+- [__#38__](https://github.com/cake-contrib/Cake.Issues/issues/38) Update XUnit to 2.4.0
+
+
+## 0.4.0-beta.2 (July 24, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- [__#38__](https://github.com/cake-contrib/Cake.Issues/issues/38) Update XUnit to 2.4.0
+
+
+## 0.4.0-beta.1 (July 24, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#35__](https://github.com/cake-contrib/Cake.Issues/issues/35) Replace `IIssue.Project` with `IIssue.ProjectFileRelativePath` and `IIssue.ProjectName`.
+## 0.3.1 (June 20, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues/issues?milestone=4&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Feature__
+
+- [__#27__](https://github.com/cake-contrib/Cake.Issues/issues/27) Add alias for creating issues from Cake scripts
+
+
+## 0.3.0 (June 03, 2018)
+
+
+As part of this release we had [14 commits](https://github.com/cake-contrib/Cake.Issues/compare/0.2.0...0.3.0) which resulted in [6 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=3&state=closed) being closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#29__](https://github.com/cake-contrib/Cake.Issues/issues/29) Make priority optional
+- [__#28__](https://github.com/cake-contrib/Cake.Issues/issues/28) Build against Cake 0.28.0
+- [__#26__](https://github.com/cake-contrib/Cake.Issues/issues/26) Add fluent API for Issue creation
+- [__#22__](https://github.com/cake-contrib/Cake.Issues/issues/22) Add PriorityName to IIssue
+- [__#21__](https://github.com/cake-contrib/Cake.Issues/issues/21) Add ProviderName to IIssue
+
+__Feature__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues/issues/25) Add constants for priority values and names
+
+
+## 0.3.0-beta.4 (June 03, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Bug Fix__
+
+- Fix argument checking in fluent API
+
+## 0.3.0-beta.3 (June 03, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- Allow default values in fluent API
+## 0.3.0-beta.2 (June 01, 2018)
+
+
+As part of this release we had 4 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#29__](https://github.com/cake-contrib/Cake.Issues/issues/29) Make `IIssue.Priority` optional
+- [__#28__](https://github.com/cake-contrib/Cake.Issues/issues/28) Build against Cake 0.28.0
+- [__#26__](https://github.com/cake-contrib/Cake.Issues/issues/26) Add fluent API for Issue creation
+
+__Feature__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues/issues/25) Add constants for priority values and names
+
+
+## 0.3.0-beta.1 (May 31, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#22__](https://github.com/cake-contrib/Cake.Issues/issues/22) Add `PriorityName` to `IIssue`
+- [__#21__](https://github.com/cake-contrib/Cake.Issues/issues/21) Add `ProviderName` to `IIssue`
+
+
+## 0.2.0 (May 21, 2018)
+
+
+As part of this release we had [6 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=2&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#13__](https://github.com/cake-contrib/Cake.Issues/issues/13) Build against Cake 0.26.0
+
+__Features__
+
+- [__#5__](https://github.com/cake-contrib/Cake.Issues/issues/5) Add project to `IIssue`
+- [__#4__](https://github.com/cake-contrib/Cake.Issues/issues/4) Migrate to .NET Standard (Thanks [Tim Johnson](https://github.com/t-johnson)!)
+
+__Improvements__
+
+- [__#20__](https://github.com/cake-contrib/Cake.Issues/issues/20) Make `IIssue.Rule` an optional parameter
+- [__#8__](https://github.com/cake-contrib/Cake.Issues/issues/8) Upgrade XUnit to 2.3.0
+
+
+## 0.2.0-beta.4 (March 07, 2018)
+
+
+As part of this release we had the following issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- Only target .NET Standard 2.0
+## 0.2.0-beta.3 (March 07, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#13__](https://github.com/cake-contrib/Cake.Issues/issues/13) Build against Cake 0.26.0
+## 0.2.0-beta.2 (December 24, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Standard 2.0
+
+__Improvements__
+
+- [__#8__](https://github.com/cake-contrib/Cake.Issues/issues/8) Upgrade XUnit to 2.3.0
+## 0.2.0-beta.1 (October 15, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#5__](https://github.com/cake-contrib/Cake.Issues/issues/5) Add project to `IIssue`
+- [__#4__](https://github.com/cake-contrib/Cake.Issues/issues/4) Migrate to .NET Standard (Thanks [Tim Johnson](https://github.com/t-johnson)!)
+
+
+## 0.1.0 (September 16, 2017)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=1&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Framework 4.6
+
+__Breaking change__
+
+- [__#3__](https://github.com/cake-contrib/Cake.Issues/issues/3) Update to Cake 0.22
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+## 0.1.0-beta.4 (September 13, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Framework 4.6
+
+__Breaking Changes__
+
+- Target .NET Framework 4.6
+- Build against Cake 0.22.0
+## 0.1.0-beta.3 (September 03, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Breaking Changes__
+
+- Move everything into single namespace.
+## 0.1.0-beta.2 (September 02, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Enhancements__
+
+- Add method `Issue<T>.GetProviderTypeName()` for returning provider type name
+- Put aliases for reading issues in own category
+## 0.1.0-beta.1 (September 01, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+
+- Add method `Issue<T>.GetProviderTypeName()` for returning provider type name
+- Put aliases for reading issues in own category
+## 0.1.0-beta.1 (September 01, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+.2
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+

--- a/input/docs/overview/release-notes/Cake.Issues.Reporting.md
+++ b/input/docs/overview/release-notes/Cake.Issues.Reporting.md
@@ -1,0 +1,1036 @@
+---
+Title: Cake.Issues.Reporting Release Notes
+Description: Release notes for Cake.Issues.Reporting
+---
+<p>
+<div class="alert alert-warning">
+<p>
+Starting with Cake.Issues 1.0, release notes for Cake.Issues.Reporting will be listed with <a href='/docs/overview/release-notes/Cake.Issues'>Cake.Issues Release Notes</a>.
+The release notes on this page are only for versions of Cake.Issues.Reporting prior to 1.0.
+</p>
+</div>
+</p>
+
+## 0.9.0 (August 22, 2020)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.Reporting/milestone/11?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.x
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#115__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/115) Update to Cake.Issues 0.9.0
+
+
+## 0.9.0-beta.2 (August 01, 2020)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.0-beta0004
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- Update to Cake.Issues 0.9.0-beta0004
+
+
+## 0.9.0-beta.1 (July 12, 2020)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.9.0-beta0002
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#115__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/115) Update to Cake.Issues 0.9.0
+
+
+## 0.8.0 (October 17, 2019)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/milestone/10?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.0
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#85__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/85) Update to Cake.Issues 0.8.0
+
+__Improvement__
+
+- [__#89__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/89) Embed NuGet package icon
+
+
+## 0.8.0-beta.1 (October 11, 2019)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.Reporting/milestone/10?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.8.0-beta.1
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#85__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/85) Update to Cake.Issues 0.8.0
+
+
+## 0.7.0 (May 30, 2019)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/milestone/9?closed=1) closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.7.x
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#53__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/53) Update to Cake.Issues 0.7.0
+- [__#52__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/52) Build against Cake 0.33.0
+
+
+## 0.7.0-beta.1 (April 19, 2019)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.33.0 or higher
+- Cake.Issues 0.7.x
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#53__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/53) Update to Cake.Issues 0.7.0
+- [__#52__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/52) Build against Cake 0.33.0
+
+
+## 0.6.1 (December 01, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=8&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+- Targeting .NET Standard 2.0
+
+__Feature__
+
+- [__#5__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/5) Migrate to .NET Standard (Thanks [Vadim Hatsura](https://github.com/vhatsura))
+
+
+## 0.6.0 (August 24, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=7&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.x
+
+__Breaking change__
+
+- [__#26__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/26) Update to Cake.Issues 0.6.0
+
+
+## 0.6.0-beta.2 (August 20, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.0-beta.2
+
+__Breaking change__
+
+- Update to Cake.Issues 0.6.0 Beta 2
+
+
+## 0.6.0-beta.1 (August 19, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.6.0-beta.1
+
+__Breaking change__
+
+- [__#26__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/26) Update to Cake.Issues 0.6.0
+
+
+## 0.5.0 (August 17, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=6&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.5.x
+
+__Breaking change__
+
+- [__#23__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/23) Update to Cake.Issues 0.5.0
+
+__Improvement__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/25) Add repository metadata to nuspec
+
+
+## 0.5.0-beta.1 (August 07, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.5.0-beta.2
+
+__Breaking change__
+
+- [__#23__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/23) Update to Cake.Issues 0.5.0
+
+
+## 0.4.0 (July 28, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=5&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.x
+
+__Breaking change__
+
+- [__#21__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/21) Update to Cake.Issues 0.4.0
+
+
+## 0.4.0-beta.2 (July 25, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.0-beta.2
+
+__Breaking change__
+
+- Update Cake.Issues to 0.4.0-beta.2
+
+
+## 0.4.0-beta.1 (July 24, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.4.0-beta.1
+
+__Breaking change__
+
+- [__#21__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/21) Update to Cake.Issues 0.4.0
+
+
+## 0.3.0 (June 04, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=4&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.3.x
+
+__Breaking changes__
+
+- [__#17__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/17) Build against Cake 0.28.0
+- [__#15__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/15) Update to Cake.Issues 0.3.0
+
+
+## 0.3.0-beta.2 (June 01, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Cake.Issues 0.3.0-beta.2
+
+__Breaking changes__
+
+- [__#17__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/17) Build against Cake 0.28.0
+- Update to Cake.Issues 0.3.0-beta.2
+
+## 0.3.0-beta.1 (May 31, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.3.0-beta.1
+
+__Breaking change__
+
+- [__#15__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/15) Update to Cake.Issues 0.3.0
+
+
+## 0.2.1 (May 25, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=3&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.x
+
+__Documentation__
+
+- [__#13__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/13) Update examples to current version of Cake.Issues.Reporting.Generic
+
+
+## 0.2.0 (May 23, 2018)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=2&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.x
+
+__Breaking changes__
+
+- [__#10__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/10) Build against Cake 0.26.0
+- [__#9__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/9) Update to Cake.Issues 0.2.0
+
+
+## 0.2.0-beta.2 (May 23, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.x
+
+__Breaking changes__
+
+- Target .NET Framework 4.6.1 instead of 4.62
+
+
+## 0.2.0-beta.1 (May 23, 2018)
+
+
+As part of this release we had 3 issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Cake.Issues 0.2.x
+
+__Breaking changes__
+
+- [__#10__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/10) Build against Cake 0.26.0
+- [__#9__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/9) Update to Cake.Issues 0.2.0
+
+
+## 0.1.0 (October 16, 2017)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues.Reporting/issues?milestone=1&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Cake.Issues 0.1.0
+
+__Breaking change__
+
+- [__#3__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/3) Update to Cake 0.22
+
+__Feature__
+
+- [__#1__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/1) Basic implementation
+
+
+## 0.1.0-beta.6 (September 16, 2017)
+
+
+As part of this release we had 2 issue closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Cake.Issues 0.1.0
+
+__Breaking Changes__
+
+- Build against Cake.Issues 0.1.0
+
+__Features__
+
+- Add alias for single issue provider
+## 0.1.0-beta.5 (September 13, 2017)
+
+
+As part of this release we had 3 issue closed.
+
+__Requirements__
+
+- Cake 0.22.0  - Cake 0.25.0
+- Cake.Issues 0.1.0-beta.4
+
+__Breaking Changes__
+
+- Target .NET Framework 4.6
+- Build against Cake 0.22.0
+- Build against Cake.Issues 0.1.0-beta0004
+## 0.1.0-beta.4 (September 10, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.3
+
+__Breaking Changes__
+
+- Add `CreateIssueReportSettings` and requirement to pass in output file path
+## 0.1.0-beta.3 (September 10, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.3
+
+__Breaking Changes__
+
+- Update Cake.Issues to 0.1.0-beta0003
+## 0.1.0-beta.2 (September 09, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.1
+
+__Feature__
+
+- Move everything into single namespace
+## 0.1.0-beta.1 (September 09, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Cake.Issues 0.1.0-beta.1
+
+__Feature__
+
+- [__#1__](https://github.com/cake-contrib/Cake.Issues.Reporting/issues/1) Basic implementation
+
+
+https://github.com/cake-contrib/Cake.Issues/issues/97) XML comment for `IIssue.ProjectFileRelativePath` mentions `string.Empty` as valid value
+
+
+## 0.6.2 (September 05, 2018)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=10&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Bug__
+
+- [__#60__](https://github.com/cake-contrib/Cake.Issues/issues/60) `ByteArrayExtensions.ToStringUsingEncoding` throws an exception if empty byte array is passed
+
+__Improvements__
+
+- [__#62__](https://github.com/cake-contrib/Cake.Issues/issues/62) `ToStringUsingEncoding` should not throw if no preamble exists
+- [__#46__](https://github.com/cake-contrib/Cake.Issues/issues/46) Add test cases for `Cake.Issues.Testing`
+
+
+## 0.6.2-beta.2 (September 05, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- [__#46__](https://github.com/cake-contrib/Cake.Issues/issues/46) Add test cases for Cake.Issues.Testing
+
+
+## 0.6.2-beta.1 (September 04, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Bug__
+
+- [__#60__](https://github.com/cake-contrib/Cake.Issues/issues/60) ByteArrayExtensions.ToStringUsingEncoding throws an exception if empty byte array is passed
+
+__Improvement__
+
+- [__#62__](https://github.com/cake-contrib/Cake.Issues/issues/62) ToStringUsingEncoding should not throw if no preamble exists
+
+
+## 0.6.1 (September 02, 2018)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=9&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#57__](https://github.com/cake-contrib/Cake.Issues/issues/57) Add method for replacing issues tokens in string
+- [__#56__](https://github.com/cake-contrib/Cake.Issues/issues/56) Add extensions for `IIssue` project and file
+
+
+## 0.6.1-beta.1 (August 26, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#57__](https://github.com/cake-contrib/Cake.Issues/issues/57) Add method for replacing issues tokens in string
+- [__#56__](https://github.com/cake-contrib/Cake.Issues/issues/56) Add extensions for `IIssue` project and file
+
+
+## 0.6.0 (August 24, 2018)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=8&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#54__](https://github.com/cake-contrib/Cake.Issues/issues/54) `BaseMultiFormatIssueProvider.ReadIssues` ignores format
+- [__#50__](https://github.com/cake-contrib/Cake.Issues/issues/50) Add method to check if initialized was called on `BaseIssueComponent`
+
+__Bug__
+
+- [__#53__](https://github.com/cake-contrib/Cake.Issues/issues/53) Typo in comment for `BaseMultiFormatIssueProvider`
+
+
+## 0.6.0-beta.2 (August 19, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#54__](https://github.com/cake-contrib/Cake.Issues/issues/54) BaseMultiFormatIssueProvider.ReadIssues ignores format
+## 0.6.0-beta.1 (August 18, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#50__](https://github.com/cake-contrib/Cake.Issues/issues/50) Add method to check if initialized was called on BaseIssueComponent
+
+__Bug__
+
+- [__#53__](https://github.com/cake-contrib/Cake.Issues/issues/53) Typo in comment for BaseMultiFormatIssueProvider
+
+
+## 0.5.0 (August 17, 2018)
+
+
+As part of this release we had [4 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=7&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#44__](https://github.com/cake-contrib/Cake.Issues/issues/44) Improve issue provider infrastructure
+
+__Features__
+
+- [__#48__](https://github.com/cake-contrib/Cake.Issues/issues/48) Add helper for string / byte array conversion
+- [__#47__](https://github.com/cake-contrib/Cake.Issues/issues/47) Add helper for working with embedded resources on file system
+
+__Improvement__
+
+- [__#49__](https://github.com/cake-contrib/Cake.Issues/issues/49) Add repository metadata to nuspec
+
+
+## 0.5.0-beta.3 (August 17, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- [__#49__](https://github.com/cake-contrib/Cake.Issues/issues/49) Add repository metadata to nuspec
+
+
+## 0.5.0-beta.2 (August 06, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#48__](https://github.com/cake-contrib/Cake.Issues/issues/48) Add helper for string / byte array conversion
+- [__#47__](https://github.com/cake-contrib/Cake.Issues/issues/47) Add helper for working with embedded resources on file system
+
+
+## 0.5.0-beta.1 (August 05, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues/issues?milestone=7&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#44__](https://github.com/cake-contrib/Cake.Issues/issues/44) Improve issue provider infrastructure
+
+
+## 0.4.1 (August 03, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues/issues?milestone=6&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Feature__
+
+- [__#39__](https://github.com/cake-contrib/Cake.Issues/issues/39) Provide infrastructure for issue provider with different formats
+
+
+## 0.4.0 (July 28, 2018)
+
+
+As part of this release we had [3 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=5&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#35__](https://github.com/cake-contrib/Cake.Issues/issues/35) Replace `IIssue.Project` with `IIssue.ProjectFileRelativePath` and `IIssue.ProjectName`
+
+__Improvement__
+
+- [__#38__](https://github.com/cake-contrib/Cake.Issues/issues/38) Update XUnit to 2.4.0
+
+
+## 0.4.0-beta.2 (July 24, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- [__#38__](https://github.com/cake-contrib/Cake.Issues/issues/38) Update XUnit to 2.4.0
+
+
+## 0.4.0-beta.1 (July 24, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#35__](https://github.com/cake-contrib/Cake.Issues/issues/35) Replace `IIssue.Project` with `IIssue.ProjectFileRelativePath` and `IIssue.ProjectName`.
+## 0.3.1 (June 20, 2018)
+
+
+As part of this release we had [1 issue](https://github.com/cake-contrib/Cake.Issues/issues?milestone=4&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Feature__
+
+- [__#27__](https://github.com/cake-contrib/Cake.Issues/issues/27) Add alias for creating issues from Cake scripts
+
+
+## 0.3.0 (June 03, 2018)
+
+
+As part of this release we had [14 commits](https://github.com/cake-contrib/Cake.Issues/compare/0.2.0...0.3.0) which resulted in [6 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=3&state=closed) being closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#29__](https://github.com/cake-contrib/Cake.Issues/issues/29) Make priority optional
+- [__#28__](https://github.com/cake-contrib/Cake.Issues/issues/28) Build against Cake 0.28.0
+- [__#26__](https://github.com/cake-contrib/Cake.Issues/issues/26) Add fluent API for Issue creation
+- [__#22__](https://github.com/cake-contrib/Cake.Issues/issues/22) Add PriorityName to IIssue
+- [__#21__](https://github.com/cake-contrib/Cake.Issues/issues/21) Add ProviderName to IIssue
+
+__Feature__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues/issues/25) Add constants for priority values and names
+
+
+## 0.3.0-beta.4 (June 03, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Bug Fix__
+
+- Fix argument checking in fluent API
+
+## 0.3.0-beta.3 (June 03, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Improvement__
+
+- Allow default values in fluent API
+## 0.3.0-beta.2 (June 01, 2018)
+
+
+As part of this release we had 4 issues closed.
+
+__Requirements__
+
+- Cake 0.28.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#29__](https://github.com/cake-contrib/Cake.Issues/issues/29) Make `IIssue.Priority` optional
+- [__#28__](https://github.com/cake-contrib/Cake.Issues/issues/28) Build against Cake 0.28.0
+- [__#26__](https://github.com/cake-contrib/Cake.Issues/issues/26) Add fluent API for Issue creation
+
+__Feature__
+
+- [__#25__](https://github.com/cake-contrib/Cake.Issues/issues/25) Add constants for priority values and names
+
+
+## 0.3.0-beta.1 (May 31, 2018)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking changes__
+
+- [__#22__](https://github.com/cake-contrib/Cake.Issues/issues/22) Add `PriorityName` to `IIssue`
+- [__#21__](https://github.com/cake-contrib/Cake.Issues/issues/21) Add `ProviderName` to `IIssue`
+
+
+## 0.2.0 (May 21, 2018)
+
+
+As part of this release we had [6 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=2&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#13__](https://github.com/cake-contrib/Cake.Issues/issues/13) Build against Cake 0.26.0
+
+__Features__
+
+- [__#5__](https://github.com/cake-contrib/Cake.Issues/issues/5) Add project to `IIssue`
+- [__#4__](https://github.com/cake-contrib/Cake.Issues/issues/4) Migrate to .NET Standard (Thanks [Tim Johnson](https://github.com/t-johnson)!)
+
+__Improvements__
+
+- [__#20__](https://github.com/cake-contrib/Cake.Issues/issues/20) Make `IIssue.Rule` an optional parameter
+- [__#8__](https://github.com/cake-contrib/Cake.Issues/issues/8) Upgrade XUnit to 2.3.0
+
+
+## 0.2.0-beta.4 (March 07, 2018)
+
+
+As part of this release we had the following issues closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- Only target .NET Standard 2.0
+## 0.2.0-beta.3 (March 07, 2018)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.26.0 or higher
+- Targeting .NET Standard 2.0
+
+__Breaking change__
+
+- [__#13__](https://github.com/cake-contrib/Cake.Issues/issues/13) Build against Cake 0.26.0
+## 0.2.0-beta.2 (December 24, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Standard 2.0
+
+__Improvements__
+
+- [__#8__](https://github.com/cake-contrib/Cake.Issues/issues/8) Upgrade XUnit to 2.3.0
+## 0.2.0-beta.1 (October 15, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Standard 2.0
+
+__Features__
+
+- [__#5__](https://github.com/cake-contrib/Cake.Issues/issues/5) Add project to `IIssue`
+- [__#4__](https://github.com/cake-contrib/Cake.Issues/issues/4) Migrate to .NET Standard (Thanks [Tim Johnson](https://github.com/t-johnson)!)
+
+
+## 0.1.0 (September 16, 2017)
+
+
+As part of this release we had [2 issues](https://github.com/cake-contrib/Cake.Issues/issues?milestone=1&state=closed) closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Framework 4.6
+
+__Breaking change__
+
+- [__#3__](https://github.com/cake-contrib/Cake.Issues/issues/3) Update to Cake 0.22
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+## 0.1.0-beta.4 (September 13, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.22.0 - Cake 0.25.0
+- Targeting .NET Framework 4.6
+
+__Breaking Changes__
+
+- Target .NET Framework 4.6
+- Build against Cake 0.22.0
+## 0.1.0-beta.3 (September 03, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Breaking Changes__
+
+- Move everything into single namespace.
+## 0.1.0-beta.2 (September 02, 2017)
+
+
+As part of this release we had 2 issues closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Enhancements__
+
+- Add method `Issue<T>.GetProviderTypeName()` for returning provider type name
+- Put aliases for reading issues in own category
+## 0.1.0-beta.1 (September 01, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+d `Issue<T>.GetProviderTypeName()` for returning provider type name
+- Put aliases for reading issues in own category
+## 0.1.0-beta.1 (September 01, 2017)
+
+
+As part of this release we had 1 issue closed.
+
+__Requirements__
+
+- Cake 0.16.2 - Cake 0.21.1
+- Targeting .NET Framework 4.5.2
+
+__Feature__
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+
+_
+
+- [__#2__](https://github.com/cake-contrib/Cake.Issues/issues/2) First version based on Cake.Prca
+
+


### PR DESCRIPTION
Fix old release notes for merged packages instead of regenerating them on every build.

Also adds a not to them, that they only contain release notes for old releases.