### PR TITLE
Fix build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = 'Stop'
-
 $SCRIPT_NAME = "build.cake"
 
 Write-Host "Restoring .NET Core tools"


### PR DESCRIPTION
Fix build by not canceling build when an error is reported, since Git Release Manager will output warnings.